### PR TITLE
add some README info on setup, and let the npm "build" target remove …

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # autocrypt-thunderbird
 WIP Extension for Autocrypt in Thunderbird
+
+## installing in development mode 
+
+You need Thunderbird 52. 
+
+Then link your/a Thunderbird profile with the autocrypt-thunderbird extension:
+
+- Use Mozilla's [extension installation
+  instruction](https://developer.mozilla.org/en-US/docs/Mozilla/Thunderbird/Thunderbird_extensions/Building_a_Thunderbird_extension_7:_Installation) and where you create "the file to reference your extension files", use "autocrypt@autocrypt.org" as filename
+ and put in a single line that is the path to the directory of your checkout of autocrypt-thunderbird. 
+
+- Initially and after any change you need to run:
+
+  - "npm install" 
+  - "npm run build" 
+  - restart Thunderbird 
+  - autocrypt-thunderbird plugin should be active
+
+

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "browserify -r buffer -r crypto-browserify:crypto content/src/messengercompose.js > content/messengercompose.js",
+    "build": "npm run build-removeasm && npm run build-js",
+    "build-js": "browserify -r buffer -r crypto-browserify:crypto content/src/messengercompose.js > content/messengercompose.js",
+    "build-removeasm": "grep -v 'use asm' <node_modules/openpgp/dist/openpgp.js >node_modules/openpgp/dist/openpgp-noasm.js ; mv node_modules/openpgp/dist/openpgp-noasm.js node_modules/openpgp/dist/openpgp.js",
     "package": "npm run build && ./package.sh"
   },
   "repository": {


### PR DESCRIPTION
…the "use asm" lines in openpgp.js automatically