### PR TITLE
add emailsj-mime-builder as dev dependeny

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "randombytes": "^2.0.6"
   },
   "devDependencies": {
+    "emailjs-mime-builder": "^1.0.1",
     "browserify": "^16.1.1",
     "watchify": "^3.11.0"
   }


### PR DESCRIPTION
So far it is a dev dependency of autocryptjs. So it does not get
installed during npm install.

npm run build fails for me due to missing this in
```
content/src/messengercompose.js:var MimeBuilder = require(emailjs-mime-builder)
```

This made the build run for me :smiley: 
Not sure this is the proper way to handle this. Feel free to just close the pr and do the right thing.